### PR TITLE
增加对 Extended Grapheme Cluster 的支持

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 const Telegraf = require('telegraf')
 const rateLimit = require('telegraf-ratelimit')
+const GraphemeSplitter = require('grapheme-splitter');
+const splitter = new GraphemeSplitter();
 
 // generate id for result
 function hash(str) {
@@ -14,7 +16,7 @@ function hash(str) {
 }
 
 function split(str) {
-  return [...str].join(' ')
+  return splitter.splitGraphemes("abcd").join(' ')
 }
 
 // Set limit to 1 message per 0.5 seconds

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "grapheme-splitter": "^1.0.4",
     "telegraf": "^3.25.0",
     "telegraf-ratelimit": "^2.0.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,6 +21,11 @@ debug@^4.0.1:
   dependencies:
     ms "^2.1.1"
 
+grapheme-splitter@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
+  integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
+
 ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"


### PR DESCRIPTION
Unicode 提供了一种算法来将一个字符串分割成若干个 grapheme cluster，以保证每一个 cluster 都是一个「在排版时不可拆分的单位」。

这个 PR 增加了对这一算法的支持。这样能够保证在拆分部分组合式 emoji、文字或符号时能够得到理想的效果。

举例：
```
abcd
before: [ 'a', 'b', 'c', 'd' ]
after: [ 'a', 'b', 'c', 'd' ]

🌷🎁💩😜👍🏳️‍🌈
before: [ '🌷', '🎁', '💩', '😜', '👍', '🏳', '️',  '‍',  '🌈' ]
after: [ '🌷', '🎁', '💩', '😜', '👍', '🏳️‍🌈' ]

Ĺo͂řȩm̅
before: [ 'L', '́', 'o', '͂', 'r', '̌', 'e', '̧', 'm', '̅' ]
after: [ 'Ĺ', 'o͂', 'ř', 'ȩ', 'm̅' ]

뎌쉐
before: [ 'ᄃ', 'ᅧ', 'ᄉ', 'ᅰ' ]
after: [ '뎌', '쉐' ]

अनुच्छेद
before: [ 'अ', 'न', 'ु', 'च', '्', 'छ', 'े', 'द' ]
after: [ 'अ', 'नु', 'च्', 'छे', 'द' ]

Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢L̠ͨͧͩ͘G̴̻͈͍͔̹̑͗̎̅͛́Ǫ̵̹̻̝̳͂̌̌͘!͖̬̰̙̗̿̋ͥͥ̂ͣ̐́́͜͞
before: [ 'Z', '͑', 'ͫ', '̓', 'ͪ', '̂', 'ͫ', '̽', '͏', '̴', '̙', '̤', '̞', '͉', '͚', '̯', '̞', '̠', '͍', 'A', 'ͫ', '͗', '̴', '͢', '̵', '̜', '̰', '͔', 'L', 'ͨ', 'ͧ', 'ͩ', '͘', '̠', 'G', '̑', '͗', '̎', '̅', '͛', '́', '̴', '̻', '͈', '͍', '͔', '̹', 'O', '͂', '̌', '̌', '͘', '̨', '̵', '̹', '̻', '̝', '̳', '!', '̿', '̋', 'ͥ', 'ͥ', '̂', 'ͣ', '̐', '́', '́', '͞', '͜', '͖', '̬', '̰', '̙', '̗' ]
after: [ 'Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍', 'A̴̵̜̰͔ͫ͗͢', 'L̠ͨͧͩ͘', 'G̴̻͈͍͔̹̑͗̎̅͛́', 'Ǫ̵̹̻̝̳͂̌̌͘', '!͖̬̰̙̗̿̋ͥͥ̂ͣ̐́́͜͞' ]
```